### PR TITLE
Create odr-dabmux user and install odr-dabmux.service

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ curl -o /etc/yum.repos.d/home:radiorabe:dab.repo \
      http://download.opensuse.org/repositories/home:/radiorabe:/dab/CentOS_7/home:radiorabe:dab.repo
      
 yum install odr-dabmux
+```
+
+### Running odr-dabmux through systemd
+
+```bash
+cp /usr/share/doc/odr-dabmux-1.0.0/example.mux /etc/odr-dabmux/dab.mux
+
+systemctl start odr-dabmux
+```

--- a/odr-dabmux.service
+++ b/odr-dabmux.service
@@ -10,5 +10,11 @@ ExecStart=/usr/bin/odr-dabmux /etc/odr-dabmux/dab.mux
 User=odr-dabmux
 Group=odr-dabmux
 
+# odr-dabmux uses real-time scheduling (with SCHED_RR and the lowest priority)
+# Let systemd change the CPU scheduler policy and priority beforhand, so that
+# root privilegs can be avoided.
+CPUSchedulingPolicy=rr
+CPUSchedulingPriority=1
+
 [Install]
 WantedBy=multi-user.target

--- a/odr-dabmux.service
+++ b/odr-dabmux.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Opendigitalradio DAB Multiplexer
+Documentation=https://github.com/Opendigitalradio/ODR-DabMux man:DabMux(1)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/odr-dabmux /etc/odr-dabmux/dab.mux
+User=odr-dabmux
+Group=odr-dabmux
+
+[Install]
+WantedBy=multi-user.target

--- a/odr-dabmux.service
+++ b/odr-dabmux.service
@@ -2,7 +2,7 @@
 Description=Opendigitalradio DAB Multiplexer
 Documentation=https://github.com/Opendigitalradio/ODR-DabMux man:DabMux(1)
 Wants=network-online.target
-After=network-online.target
+After=network-online.target sound.target
 
 [Service]
 Type=simple

--- a/odr-dabmux.spec
+++ b/odr-dabmux.spec
@@ -33,7 +33,7 @@ Summary:        ODR-DabMux is a DAB (Digital Audio Broadcasting) multiplexer.
 License:        GPLv3+
 URL:            https://github.com/Opendigitalradio/%{reponame}
 Source0:        https://github.com/Opendigitalradio/%{reponame}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-Source1:        odr-dabmux.service
+Source1:        https://raw.githubusercontent.com/radiorabe/centos-rpm-%{name}/master/%{name}.service
 
 BuildRequires:  boost-devel
 BuildRequires:  libcurl-devel

--- a/odr-dabmux.spec
+++ b/odr-dabmux.spec
@@ -33,6 +33,7 @@ Summary:        ODR-DabMux is a DAB (Digital Audio Broadcasting) multiplexer.
 License:        GPLv3+
 URL:            https://github.com/Opendigitalradio/%{reponame}
 Source0:        https://github.com/Opendigitalradio/%{reponame}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Source1:        odr-dabmux.service
 
 BuildRequires:  boost-devel
 BuildRequires:  libcurl-devel
@@ -52,6 +53,7 @@ Opendigitalradio project.
 
 %prep
 %setup -q -n %{reponame}-%{version}
+cp %SOURCE1 .
 
 
 %build
@@ -67,6 +69,10 @@ make %{?_smp_mflags}
 rm -rf $RPM_BUILD_ROOT
 %make_install
 
+# Install the systemd configuration
+install -d %{buildroot}/%{_libdir}/systemd/system
+install odr-dabmux.service %{buildroot}/%{_libdir}/systemd/system/
+
 # Rename the README.md to prevent a name clash with the top-level README.md
 mv doc/README.md doc/README-ODR-DabMux.md
 
@@ -74,11 +80,26 @@ mv doc/README.md doc/README-ODR-DabMux.md
 mkdir -p %{buildroot}%{_mandir}/man1
 mv doc/DabMux.1 %{buildroot}%{_mandir}/man1/
 
+# Install system directories
+install -d %{buildroot}/%{_sysconfdir}/%{name}
+install -d %{buildroot}/%{_sharedstatedir}/%{name}
+
+
+%pre
+getent group odr-dabmux >/dev/null || groupadd -r odr-dabmux
+getent passwd odr-dabmux >/dev/null || \
+    useradd -r -g odr-dabmux -d /var/lib/odr-dabmux -m \
+    -c "odr-dabmux system user account" odr-dabmux
+exit 0
+
 
 %files
 %doc ChangeLog README.md doc/*.txt doc/README-ODR-DabMux.md doc/*.mux
+%dir %{_sysconfdir}/%{name}
+%dir %attr(-, odr-dabmux, odr-dabmux) %{_sharedstatedir}/%{name}
 %{_bindir}/*
 %{_mandir}/man1/*
+%{_libdir}/systemd/system/*
 
 
 

--- a/odr-dabmux.spec
+++ b/odr-dabmux.spec
@@ -42,6 +42,7 @@ BuildRequires:  zeromq-devel
 Requires:       boost
 Requires:       libcurl
 Requires:       libfec-odr
+Requires:       shadow-utils
 Requires:       zeromq
 
 %description
@@ -88,7 +89,7 @@ install -d %{buildroot}/%{_sharedstatedir}/%{name}
 %pre
 getent group odr-dabmux >/dev/null || groupadd -r odr-dabmux
 getent passwd odr-dabmux >/dev/null || \
-    useradd -r -g odr-dabmux -d /var/lib/odr-dabmux -m \
+    useradd -r -g odr-dabmux -d /var/lib/odr-dabmux -m -s /sbin/nologin \
     -c "odr-dabmux system user account" odr-dabmux
 exit 0
 

--- a/odr-dabmux.spec
+++ b/odr-dabmux.spec
@@ -84,13 +84,12 @@ mv doc/DabMux.1 %{buildroot}%{_mandir}/man1/
 
 # Install system directories
 install -d %{buildroot}/%{_sysconfdir}/%{name}
-install -d %{buildroot}/%{_sharedstatedir}/%{name}
 
 
 %pre
 getent group odr-dabmux >/dev/null || groupadd -r odr-dabmux
 getent passwd odr-dabmux >/dev/null || \
-    useradd -r -g odr-dabmux -d /var/lib/odr-dabmux -m -s /sbin/nologin \
+    useradd -r -g odr-dabmux -d /dev/null -m -s /sbin/nologin \
     -c "odr-dabmux system user account" odr-dabmux
 exit 0
 
@@ -110,7 +109,6 @@ exit 0
 %files
 %doc ChangeLog README.md doc/*.txt doc/README-ODR-DabMux.md doc/*.mux
 %dir %{_sysconfdir}/%{name}
-%dir %attr(-, odr-dabmux, odr-dabmux) %{_sharedstatedir}/%{name}
 %{_bindir}/*
 %{_mandir}/man1/*
 %{_unitdir}/%{name}.service

--- a/odr-dabmux.spec
+++ b/odr-dabmux.spec
@@ -87,10 +87,10 @@ install -d %{buildroot}/%{_sysconfdir}/%{name}
 
 
 %pre
-getent group odr-dabmux >/dev/null || groupadd -r odr-dabmux
-getent passwd odr-dabmux >/dev/null || \
-    useradd -r -g odr-dabmux -d /dev/null -m -s /sbin/nologin \
-    -c "odr-dabmux system user account" odr-dabmux
+getent group %{name} >/dev/null || groupadd -r %{name}
+getent passwd %{name} >/dev/null || \
+    useradd -r -g %{name} -d /dev/null -m -s /sbin/nologin \
+    -c "%{name} system user account" %{name}
 exit 0
 
 

--- a/odr-dabmux.spec
+++ b/odr-dabmux.spec
@@ -38,12 +38,14 @@ Source1:        https://raw.githubusercontent.com/radiorabe/centos-rpm-%{name}/m
 BuildRequires:  boost-devel
 BuildRequires:  libcurl-devel
 BuildRequires:  libfec-odr-devel
+BuildRequires:  systemd
 BuildRequires:  zeromq-devel
 Requires:       boost
 Requires:       libcurl
 Requires:       libfec-odr
 Requires:       shadow-utils
 Requires:       zeromq
+%{?systemd_requires}
 
 %description
 ODR-DabMux is a DAB (Digital Audio Broadcasting) multiplexer compliant to
@@ -54,7 +56,6 @@ Opendigitalradio project.
 
 %prep
 %setup -q -n %{reponame}-%{version}
-cp %SOURCE1 .
 
 
 %build
@@ -70,9 +71,9 @@ make %{?_smp_mflags}
 rm -rf $RPM_BUILD_ROOT
 %make_install
 
-# Install the systemd configuration
-install -d %{buildroot}/%{_libdir}/systemd/system
-install odr-dabmux.service %{buildroot}/%{_libdir}/systemd/system/
+# Install the systemd service unit
+install -d %{buildroot}/%{_unitdir}
+install %{SOURCE1} %{buildroot}/%{_unitdir}
 
 # Rename the README.md to prevent a name clash with the top-level README.md
 mv doc/README.md doc/README-ODR-DabMux.md
@@ -94,13 +95,25 @@ getent passwd odr-dabmux >/dev/null || \
 exit 0
 
 
+%post
+%systemd_post %{name}.service
+
+
+%preun
+%systemd_preun %{name}.service
+
+
+%postun
+%systemd_postun_with_restart %{name}.service
+
+
 %files
 %doc ChangeLog README.md doc/*.txt doc/README-ODR-DabMux.md doc/*.mux
 %dir %{_sysconfdir}/%{name}
 %dir %attr(-, odr-dabmux, odr-dabmux) %{_sharedstatedir}/%{name}
 %{_bindir}/*
 %{_mandir}/man1/*
-%{_libdir}/systemd/system/*
+%{_unitdir}/%{name}.service
 
 
 

--- a/odr-dabmux.spec
+++ b/odr-dabmux.spec
@@ -27,7 +27,7 @@
 
 Name:           odr-dabmux
 Version:        1.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        ODR-DabMux is a DAB (Digital Audio Broadcasting) multiplexer.
 
 License:        GPLv3+
@@ -116,6 +116,10 @@ exit 0
 
 
 %changelog
+* Sat Aug 27 2016 Christian Affolter <c.affolter@purplehaze.ch> - 1.0.0-2
+- Added a dedicated system user and a systemd service unit for starting odr-dabmux
+  based on the original work done by Lucas Bickel <hairmare@rabe.ch>
+
 * Sun Aug 21 2016 Christian Affolter <c.affolter@purplehaze.ch> - 1.0.0-1
 - Initial release
 


### PR DESCRIPTION
This should make getting up and running easy. All thats needed after install is creating a conf in /etc/odr-dabmux/dab.mux and enabling it with systemd.

Note: The _service file on obs needs an update to unpack the service file after this is merged.

Fixes #1
