### PR TITLE
1.1.0 bump and cleanup service ref

### DIFF
--- a/odr-dabmux.spec
+++ b/odr-dabmux.spec
@@ -26,8 +26,8 @@
 %define reponame ODR-DabMux
 
 Name:           odr-dabmux
-Version:        1.0.0
-Release:        2%{?dist}
+Version:        1.1.0
+Release:        1%{?dist}
 Summary:        ODR-DabMux is a DAB (Digital Audio Broadcasting) multiplexer.
 
 License:        GPLv3+
@@ -116,6 +116,9 @@ exit 0
 
 
 %changelog
+* Sat Sep  3 2016 Lucas Bickel <hairmare@rabe.ch> - 1.1.0-1
+- Version bump
+
 * Sat Aug 27 2016 Christian Affolter <c.affolter@purplehaze.ch> - 1.0.0-2
 - Added a dedicated system user and a systemd service unit for starting odr-dabmux
   based on the original work done by Lucas Bickel <hairmare@rabe.ch>

--- a/odr-dabmux.spec
+++ b/odr-dabmux.spec
@@ -33,7 +33,7 @@ Summary:        ODR-DabMux is a DAB (Digital Audio Broadcasting) multiplexer.
 License:        GPLv3+
 URL:            https://github.com/Opendigitalradio/%{reponame}
 Source0:        https://github.com/Opendigitalradio/%{reponame}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
-Source1:        https://raw.githubusercontent.com/radiorabe/centos-rpm-%{name}/master/%{name}.service
+Source1:        odr-dabmux.service
 
 BuildRequires:  boost-devel
 BuildRequires:  libcurl-devel


### PR DESCRIPTION
1.1.0 was tagged yesterday, see https://github.com/Opendigitalradio/ODR-DabMux/compare/v1.0.0...v1.1.0 for the diff.

I also took the liberty to revert 394c4ba3f81908d51cd0d904ab746d8c41d45613 to ensure that the obs always gets the file matching the commit. (Important once we switch to tagged builds)
