### PR TITLE
Ensure fifo exists before starting dabmux

### DIFF
--- a/odr-dabmux.service
+++ b/odr-dabmux.service
@@ -6,6 +6,9 @@ After=network-online.target sound.target
 
 [Service]
 Type=simple
+ExecStartPre=-/bin/mkdir -p /var/tmp/dabmux
+ExecStartPre=-/bin/mkfifo --mode=644 /var/tmp/dabmux/odr-dabmux-local-01.fifo
+ExecStartPre=-/bin/chown odr-dabmux:odr-dabmux /var/tmp/dabmux/odr-dabmux-local-01.fifo
 ExecStart=/usr/bin/odr-dabmux /etc/odr-dabmux/dab.mux
 User=odr-dabmux
 Group=odr-dabmux


### PR DESCRIPTION
We would also need to change the config to use the new location. AFAIK it's only in our internal docs for /etc/odr-dabmux/dab.mux.

I'm opening this now so we can discuss if this is the way to go. Let me know if it's ok and I'll update the docs to mention the needed dabmux config and the fifo location.