### PR TITLE
Configure travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: minimal
+
+services:
+  - docker
+
+jobs:
+  include:
+    - stage: main
+      name: "RPMlint"
+      before_install:
+        - docker pull quay.io/hairmare/fedora_rpmdev
+      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/fedora_rpmdev rpmlint odr-dabmux.spec
+    - stage: main
+      name: "CentOS RPM"
+      before_install:
+        - docker pull quay.io/hairmare/centos_rpmdev
+      script: docker run --rm -ti -v `pwd`:'/git' quay.io/hairmare/centos_rpmdev /git/.travis/rpm.sh

--- a/.travis/rpm.sh
+++ b/.travis/rpm.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# RPM build wrapper for odr-dabmux, runs inside the build container on travis-ci
+
+set -xe
+
+curl -o /etc/yum.repos.d/dab.repo https://download.opensuse.org/repositories/home:/radiorabe:/dab/CentOS_7/home:radiorabe:dab.repo
+
+yum -y install \
+    epel-release
+
+chown root:root odr-dabmux.spec
+
+rpmdev-setuptree
+
+cp *.service /root/rpmbuild/SOURCES/
+
+build-rpm-package.sh odr-dabmux.spec

--- a/odr-dabmux.spec
+++ b/odr-dabmux.spec
@@ -27,7 +27,7 @@
 
 Name:           odr-dabmux
 Version:        2.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        ODR-DabMux is a DAB (Digital Audio Broadcasting) multiplexer.
 
 License:        GPLv3+
@@ -35,6 +35,7 @@ URL:            https://github.com/Opendigitalradio/%{reponame}
 Source0:        https://github.com/Opendigitalradio/%{reponame}/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 Source1:        odr-dabmux.service
 
+BuildRequires:  gcc-c++
 BuildRequires:  boost-devel
 BuildRequires:  libcurl-devel
 BuildRequires:  systemd
@@ -58,7 +59,7 @@ Opendigitalradio project.
 
 %build
 autoreconf -fi
-%configure --disable-static
+%configure
 
 make %{?_smp_mflags}
 
@@ -112,6 +113,10 @@ exit 0
 
 
 %changelog
+* Sun Dec  9 2018 Lucas Bickel <hairmare@rabe.ch> - 2.2.0-2
+- Remove unrecognized --disable-static option
+- Add gcc-c++ builddep since it isn't indirectly included anymore
+
 * Sat Aug 25 2018 Christian Affolter <c.affolter@purplehaze.ch> - 2.2.0-1
 - Version bump to 2.2.0
 


### PR DESCRIPTION
I think we have a49e62bc268bcdfc8c43520a030633f7d7acb852 since someone stopped depending on it, I think it's due to some changes in how boost is managed by upstream.

There is also an 2.3.0 bump PR that I'll base on this so you can merge them both in one go should you prefer to. It's at #10.